### PR TITLE
Clean up build warnings related to colcon

### DIFF
--- a/ad_physics/CMakeLists.txt
+++ b/ad_physics/CMakeLists.txt
@@ -28,6 +28,13 @@ find_package(spdlog REQUIRED CONFIG)
 
 include(generated/ad_physics.cmake)
 
+# Ignore additional variables added when building with colcon
+# See: https://stackoverflow.com/questions/36451368/get-rid-of-cmake-warning-manually-specified-variables-were-not-used-by-the-proj
+set(IGNORED_VARIABLES
+  ${CATKIN_INSTALL_INTO_PREFIX_ROOT}
+  ${CATKIN_SYMLINK_INSTALL}
+)
+
 add_library(${PROJECT_NAME}
   ${ad_physics_GENERATED_SOURCES}
   ${CMAKE_CURRENT_SOURCE_DIR}/src/Operation.cpp


### PR DESCRIPTION
In #1, `package.xml` file has been added to `ad_physics` library in order for `rosdep` to be able to discover it. However, this makes `colcon` interpret the library as a Catkin package (as opposed to regular CMake package), and therefore introduce some additional CMake variables. This in turn triggers the following warning:
```
Starting >>> ad_physics
--- stderr: ad_physics                                                                  
CMake Warning:
  Manually-specified variables were not used by the project:

    CATKIN_INSTALL_INTO_PREFIX_ROOT
    CATKIN_SYMLINK_INSTALL


---
Finished <<< ad_physics [4.26s]
```

This PR fixes it.